### PR TITLE
Access page design adjustments

### DIFF
--- a/x-pack/plugins/security/public/authentication/access_notice/_access_notice_page.scss
+++ b/x-pack/plugins/security/public/authentication/access_notice/_access_notice_page.scss
@@ -1,15 +1,17 @@
-.secAccessNoticePage__text {
-  @include euiScrollBar;
-
-  max-height: $euiSize * 20;
-  overflow-y: auto;
-  padding: $euiSize;
-}
-
-.secAccessNoticePage__acknowledge {
-  align-self: end;
-}
-
 .secAccessNoticePage .secAuthenticationStatePage__content {
   max-width: 600px;
+}
+
+.secAccessNoticePage__container {
+  @include euiBottomShadowSmall;
+  animation: none;
+}
+
+.secAccessNoticePage__text {
+  max-height: 400px;
+  padding-top: $euiSize;
+}
+
+.secAccessNoticePage__footer {
+  justify-content: flex-start;
 }

--- a/x-pack/plugins/security/public/authentication/access_notice/access_notice_page.tsx
+++ b/x-pack/plugins/security/public/authentication/access_notice/access_notice_page.tsx
@@ -9,7 +9,7 @@ import './_index.scss';
 import React, { FormEvent, MouseEvent, useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import ReactMarkdown from 'react-markdown';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiPanel, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { CoreStart, FatalErrorsStart, HttpStart, NotificationsStart } from 'src/core/public';
@@ -67,15 +67,16 @@ export function AccessNoticePage({ http, fatalErrors, notifications }: Props) {
       }
     >
       <form onSubmit={onAcknowledge}>
-        <EuiPanel>
-          <EuiFlexGroup justifyContent="spaceBetween" direction="column">
-            <EuiFlexItem className="secAccessNoticePage__text">
-              <EuiText textAlign="left">
-                <ReactMarkdown>{accessNotice}</ReactMarkdown>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem className="secAccessNoticePage__acknowledge">
-              <EuiSpacer size="s" />
+        <div className="euiModal secAccessNoticePage__container">
+          <div className="euiModal__flex">
+            <div className="euiModalBody euiModalBody__overflow secAccessNoticePage__text">
+              <div className="euiModalBody__overflow secAccessNoticePage__text">
+                <EuiText textAlign="left">
+                  <ReactMarkdown>{accessNotice}</ReactMarkdown>
+                </EuiText>
+              </div>
+            </div>
+            <div className="euiModalFooter secAccessNoticePage__footer">
               <EuiButton
                 fill
                 type="submit"
@@ -90,9 +91,9 @@ export function AccessNoticePage({ http, fatalErrors, notifications }: Props) {
                   defaultMessage="Acknowledge and continue"
                 />
               </EuiButton>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </EuiPanel>
+            </div>
+          </div>
+        </div>
         <EuiSpacer size="xxl" />
       </form>
     </AuthenticationStatePage>


### PR DESCRIPTION
This design PR does the following:

In lieu of custom styles and flex items, rely upon the existing modal content styles since we desire the same effect (panel with footer and scrolling content). To accomplish, I've changed the flex elements to standard divs and removed some of the custom styles; retaining only the necessary overrides.

It now looks like this:

<img width="844" alt="Screenshot 2020-04-20 08 49 34" src="https://user-images.githubusercontent.com/446285/79759880-da9b8100-82e4-11ea-81b2-d616a6a254a8.png">

<img width="916" alt="Screenshot 2020-04-20 08 46 42" src="https://user-images.githubusercontent.com/446285/79759843-cfe0ec00-82e4-11ea-94e7-9a4206111ee1.png">

<img width="602" alt="Screenshot 2020-04-20 08 47 10" src="https://user-images.githubusercontent.com/446285/79759893-dec79e80-82e4-11ea-962c-03a109131a14.png">


