### PR TITLE
Remove direct use of EuiModal classes

### DIFF
--- a/x-pack/plugins/security/public/authentication/access_notice/_access_notice_page.scss
+++ b/x-pack/plugins/security/public/authentication/access_notice/_access_notice_page.scss
@@ -15,3 +15,7 @@
 .secAccessNoticePage__footer {
   padding: $euiSize $euiSizeL $euiSizeL;
 }
+
+.secAccessNoticePage__footerInner {
+  text-align: left;
+}

--- a/x-pack/plugins/security/public/authentication/access_notice/_access_notice_page.scss
+++ b/x-pack/plugins/security/public/authentication/access_notice/_access_notice_page.scss
@@ -2,16 +2,16 @@
   max-width: 600px;
 }
 
-.secAccessNoticePage__container {
-  @include euiBottomShadowSmall;
-  animation: none;
+.secAccessNoticePage__textWrapper {
+  overflow-y: hidden;
 }
 
 .secAccessNoticePage__text {
+  @include euiYScrollWithShadows;
   max-height: 400px;
-  padding-top: $euiSize;
+  padding: $euiSize $euiSizeL 0;
 }
 
 .secAccessNoticePage__footer {
-  justify-content: flex-start;
+  padding: $euiSize $euiSizeL $euiSizeL;
 }

--- a/x-pack/plugins/security/public/authentication/access_notice/access_notice_page.tsx
+++ b/x-pack/plugins/security/public/authentication/access_notice/access_notice_page.tsx
@@ -9,7 +9,7 @@ import './_index.scss';
 import React, { FormEvent, MouseEvent, useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import ReactMarkdown from 'react-markdown';
-import { EuiButton, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiButton, EuiPanel, EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { CoreStart, FatalErrorsStart, HttpStart, NotificationsStart } from 'src/core/public';
@@ -67,33 +67,37 @@ export function AccessNoticePage({ http, fatalErrors, notifications }: Props) {
       }
     >
       <form onSubmit={onAcknowledge}>
-        <div className="euiModal secAccessNoticePage__container">
-          <div className="euiModal__flex">
-            <div className="euiModalBody euiModalBody__overflow secAccessNoticePage__text">
-              <div className="euiModalBody__overflow secAccessNoticePage__text">
+        <EuiPanel paddingSize="none" className="secAccessNoticePage__container">
+          <EuiFlexGroup gutterSize="none" direction="column">
+            <EuiFlexItem className="secAccessNoticePage__textWrapper">
+              <div className="secAccessNoticePage__text">
                 <EuiText textAlign="left">
                   <ReactMarkdown>{accessNotice}</ReactMarkdown>
                 </EuiText>
               </div>
-            </div>
-            <div className="euiModalFooter secAccessNoticePage__footer">
-              <EuiButton
-                fill
-                type="submit"
-                color="primary"
-                onClick={onAcknowledge}
-                isDisabled={isLoading}
-                isLoading={isLoading}
-                data-test-subj="accessNoticeAcknowledge"
-              >
-                <FormattedMessage
-                  id="xpack.security.accessNotice.acknowledgeButtonText"
-                  defaultMessage="Acknowledge and continue"
-                />
-              </EuiButton>
-            </div>
-          </div>
-        </div>
+            </EuiFlexItem>
+            <EuiFlexItem className="secAccessNoticePage__footer">
+              <EuiFlexGroup gutterSize="none">
+                <EuiFlexItem grow={false}>
+                  <EuiButton
+                    fill
+                    type="submit"
+                    color="primary"
+                    onClick={onAcknowledge}
+                    isDisabled={isLoading}
+                    isLoading={isLoading}
+                    data-test-subj="accessNoticeAcknowledge"
+                  >
+                    <FormattedMessage
+                      id="xpack.security.accessNotice.acknowledgeButtonText"
+                      defaultMessage="Acknowledge and continue"
+                    />
+                  </EuiButton>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
         <EuiSpacer size="xxl" />
       </form>
     </AuthenticationStatePage>

--- a/x-pack/plugins/security/public/authentication/access_notice/access_notice_page.tsx
+++ b/x-pack/plugins/security/public/authentication/access_notice/access_notice_page.tsx
@@ -67,7 +67,7 @@ export function AccessNoticePage({ http, fatalErrors, notifications }: Props) {
       }
     >
       <form onSubmit={onAcknowledge}>
-        <EuiPanel paddingSize="none" className="secAccessNoticePage__container">
+        <EuiPanel paddingSize="none">
           <EuiFlexGroup gutterSize="none" direction="column">
             <EuiFlexItem className="secAccessNoticePage__textWrapper">
               <div className="secAccessNoticePage__text">
@@ -77,24 +77,22 @@ export function AccessNoticePage({ http, fatalErrors, notifications }: Props) {
               </div>
             </EuiFlexItem>
             <EuiFlexItem className="secAccessNoticePage__footer">
-              <EuiFlexGroup gutterSize="none">
-                <EuiFlexItem grow={false}>
-                  <EuiButton
-                    fill
-                    type="submit"
-                    color="primary"
-                    onClick={onAcknowledge}
-                    isDisabled={isLoading}
-                    isLoading={isLoading}
-                    data-test-subj="accessNoticeAcknowledge"
-                  >
-                    <FormattedMessage
-                      id="xpack.security.accessNotice.acknowledgeButtonText"
-                      defaultMessage="Acknowledge and continue"
-                    />
-                  </EuiButton>
-                </EuiFlexItem>
-              </EuiFlexGroup>
+              <div className="secAccessNoticePage__footerInner">
+                <EuiButton
+                  fill
+                  type="submit"
+                  color="primary"
+                  onClick={onAcknowledge}
+                  isDisabled={isLoading}
+                  isLoading={isLoading}
+                  data-test-subj="accessNoticeAcknowledge"
+                >
+                  <FormattedMessage
+                    id="xpack.security.accessNotice.acknowledgeButtonText"
+                    defaultMessage="Acknowledge and continue"
+                  />
+                </EuiButton>
+              </div>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPanel>


### PR DESCRIPTION
Update previous design changes to not apply EuiModal classes directly.

This protects against future potential breakage as changes to class names are not monitored/considered as breaking changes in EUI.

